### PR TITLE
Exclude __entity field from relational mapper results

### DIFF
--- a/nodejs/nestjs/src/utils/relational-entity-helper.ts
+++ b/nodejs/nestjs/src/utils/relational-entity-helper.ts
@@ -1,7 +1,8 @@
-import { instanceToPlain } from 'class-transformer';
+import { Exclude, instanceToPlain } from 'class-transformer';
 import { AfterLoad, BaseEntity } from 'typeorm';
 
 export class EntityRelationalHelper extends BaseEntity {
+  @Exclude()
   __entity?: string;
 
   @AfterLoad()


### PR DESCRIPTION
This field is muddling up JSON results from the API, let's exclude it explicitly!